### PR TITLE
Add support for additional Gerber file extensions in file picker

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,8 +36,8 @@
         <div class="import-section">
           <div class="button-row">
             <input type="file" id="jobFile" accept=".json" style="display: none;" />
-            <input type="file" id="pasteGerberFile" accept=".gbr" style="display: none;" />
-            <input type="file" id="maskGerberFile" accept=".gbr" style="display: none;" />
+            <input type="file" id="pasteGerberFile" accept=".gbr,.gbp,.gtp" style="display: none;" />
+            <input type="file" id="maskGerberFile" accept=".gbr,.gbs,.gts" style="display: none;" />
             <button class="goldenrod-button" id="importJob" type="button">Import Job</button>
             OR
             <button class="goldenrod-button" id="selectPasteGerber" type="button">Select Paste Gerber</button>


### PR DESCRIPTION
Added paste-specific Gerber extensions (.gbp, .gtp) to the paste Gerber file picker and mask-specific extensions (.gbs, .gts) to the mask Gerber file picker, in addition to the standard .gbr extension.

The exported paste and mask gerbers from KiCad 9 uses these extensions at least.